### PR TITLE
Add support for pug

### DIFF
--- a/index.js
+++ b/index.js
@@ -23,14 +23,14 @@ module.exports = function jadeConcat(fileName, _opts) {
     var filename = file.path.replace(file.base, "").replace(".js", "");
 
     // replace template name with filename
-    var contents = file.contents.toString().replace('function template', '"' + filename + '": function')
+    var contents = file.contents.toString();
 
-    concatString += contents + ",\n";;
+    concatString += '(function(){' + contents + '\n' + _opts.templateVariable + '["' + filename + '"]=template;})();';
   }
 
   function end () {
     //wrap concatenated string in template object
-    var templateString = "var " + _opts.templateVariable + " = {\n" + concatString + "}";
+    var templateString = "var " + _opts.templateVariable + " = {};" + concatString;
 
     this.queue(new gutil.File({
       path: fileName,

--- a/index.js
+++ b/index.js
@@ -20,7 +20,7 @@ module.exports = function jadeConcat(fileName, _opts) {
     if (file.isStream()) return this.emit('error', pluginError('Streaming not supported'))
 
     //isolate filename from full path
-    var filename = file.path.replace(file.base, "").replace(".js", "");
+    var filename = file.path.replace(file.base, "").replace("/", "").replace(".js", "");
 
     // replace template name with filename
     var contents = file.contents.toString();

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "gulp-util": "*"
   },
   "peerDependencies": {
-    "jade": "*"
+    "pug": "*"
   },
   "bugs": {
     "url": "https://github.com/nStonehouse/gulp-jade-template-concat/issues"


### PR DESCRIPTION
Either will do.

```
gulp.task('template:pug', function() {
    return gulp.src('./*.pug')
        .pipe(pug({client:true, compileDebug:false}))
        .pipe(jadeConcat('template.js', {templateVariable:"PugTemplate"}))
        .pipe(gulp.dest('./js'));
});
```

```
gulp.task('template:jade', function() {
    return gulp.src('./*.jade')
        .pipe(jade({client:true}))
        .pipe(jadeConcat('template.js', {templateVariable:"JadeTemplate"}))
        .pipe(gulp.dest('./js'));
});
```
