### PR TITLE
defaults taken into account now, Array.push() and .join() instead of string concat

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+node_modules/

--- a/index.js
+++ b/index.js
@@ -1,6 +1,7 @@
 var gutil = require('gulp-util');
 var PluginError = gutil.PluginError;
 var through = require('through');
+var extend = require('lodash/fp/extend');
 
 
 function pluginError (message) {
@@ -11,8 +12,8 @@ function pluginError (message) {
 module.exports = function jadeConcat(fileName, _opts) {
   if (!fileName) throw pluginError('Missing fileName')
 
-  var defaults = {templateVariable: "templates"}
-  var concatString = "";
+  var opts = extend({templateVariable: "templates"}, _opts);
+  var templates = [];
 
 
   function write (file) {
@@ -25,12 +26,12 @@ module.exports = function jadeConcat(fileName, _opts) {
     // replace template name with filename
     var contents = file.contents.toString().replace('function template', '"' + filename + '": function')
 
-    concatString += contents + ",\n";;
+    templates.push(contents);
   }
 
   function end () {
     //wrap concatenated string in template object
-    var templateString = "var " + _opts.templateVariable + " = {\n" + concatString + "}";
+    var templateString = "var " + opts.templateVariable + " = {\n" + templates.join(",\n") + "\n}";
 
     this.queue(new gutil.File({
       path: fileName,

--- a/package.json
+++ b/package.json
@@ -20,8 +20,9 @@
   "author": "Nicholas Stonehouse",
   "license": "MIT",
   "dependencies": {
-    "through": "*",
-    "gulp-util": "*"
+    "gulp-util": "*",
+    "lodash": "^4.13.1",
+    "through": "*"
   },
   "peerDependencies": {
     "jade": "*"


### PR DESCRIPTION
Hi,

Kudos for this little gem! I am gladly using it in my project.

I've enhanced your code a little bit:
- Added `.gitignore` file to ignore the `node_modules` folder when committing to Git.
- Added `lodash` to dependencies and use the `extend()` method from it to merge passed options with default options.
- Removed string concatenation (of `concatString`) in favor of `push()`ing into an array and finally `join()`ing it to a string. This avoids the trailing `,` in the end of the (now obsolete/replaced) `concatString`.

Please consider a pull/merge.

Regards,
Sven
